### PR TITLE
Add installation to qmake project

### DIFF
--- a/data/data.pro
+++ b/data/data.pro
@@ -1,0 +1,16 @@
+TEMPLATE = subdirs
+
+isEmpty(PREFIX) {
+    PREFIX = /usr
+}
+isEmpty(DATADIR) {
+    DATADIR = $${PREFIX}/share
+}
+
+desktop.path = $${DATADIR}/applications
+desktop.files = sysmon-qt.desktop
+
+icon.path = $${DATADIR}/pixmaps
+icon.files = sysmon-qt.png
+
+INSTALLS += desktop icon

--- a/src/src.pro
+++ b/src/src.pro
@@ -3,7 +3,7 @@ QT       += core gui widgets network
 TARGET   = sysmon-qt
 TEMPLATE = app
 
-HEADERS += sysmon-qt.h  \
+HEADERS = sysmon-qt.h  \
            sm_widgets.h \
            sm_config.h  \
            sm_color.h   \
@@ -11,10 +11,18 @@ HEADERS += sysmon-qt.h  \
            sm_temps.h   \
            version.h
 
-SOURCES += sysmon-qt.cpp  \
+SOURCES = sysmon-qt.cpp  \
            sm_widgets.cpp \
            sm_config.cpp  \
            sm_color.cpp   \
            sm_temps.cpp   \
            sm_font.cpp
 
+isEmpty(PREFIX) {
+    PREFIX = /usr
+}
+isEmpty(BINDIR) {
+    BINDIR = $${PREFIX}/bin
+}
+target.path = $$BINDIR
+INSTALLS += target

--- a/sysmon-qt.pro
+++ b/sysmon-qt.pro
@@ -1,0 +1,2 @@
+TEMPLATE = subdirs
+SUBDIRS += data src


### PR DESCRIPTION
This is just a small adjustment to the qmake project files to enable `make install` to work instead of requiring a manual installation.